### PR TITLE
Return a value so Ruby 1.9.3 doesnt blow up 

### DIFF
--- a/ext/svd.c
+++ b/ext/svd.c
@@ -21,7 +21,7 @@ VALUE decompose(VALUE module, VALUE matrix_ruby, VALUE m_ruby, VALUE n_ruby) {
 	/* precondition */
 	if((m*n) != RARRAY_LEN(matrix_ruby)) {
 		rb_raise(rb_eRangeError, "Size of the array is not equal to m * n");
-		return;
+		return output;
 	}
 	
 	/* convert to u matrix */


### PR DESCRIPTION
When installing ruby-svd on Ruby 1.9.3, it will not install:

Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

```
    /Users/ryan/.rvm/rubies/ruby-1.9.3-p125/bin/ruby extconf.rb -Wreturn-type
```

creating Makefile

make
compiling svd.c
In file included from svd.c:3:
In file included from ./svd.h:6:
./nrutil.h:106:19: warning: passing 'const char [31]' to parameter of type 'char _' discards qualifiers
  if (!v) nrerror("allocation failure in vector()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:116:19: warning: passing 'const char [32]' to parameter of type 'char *' discards qualifiers
  if (!v) nrerror("allocation failure in ivector()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:127:19: warning: passing 'const char [32]' to parameter of type 'char *' discards qualifiers
  if (!v) nrerror("allocation failure in cvector()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:137:19: warning: passing 'const char [32]' to parameter of type 'char *' discards qualifiers
  if (!v) nrerror("allocation failure in lvector()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:147:19: warning: passing 'const char [32]' to parameter of type 'char *' discards qualifiers
  if (!v) nrerror("allocation failure in dvector()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:159:19: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m) nrerror("allocation failure 1 in matrix()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:165:24: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:183:19: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m) nrerror("allocation failure 1 in matrix()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:189:24: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:207:19: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m) nrerror("allocation failure 1 in matrix()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:213:24: warning: passing 'const char [33]' to parameter of type 'char *' discards qualifiers
  if (!m[nrl]) nrerror("allocation failure 2 in matrix()");
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:234:19: warning: passing 'const char [34]' to parameter of type 'char *' discards qualifiers
  if (!m) nrerror("allocation failure in submatrix()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:256:19: warning: passing 'const char [39]' to parameter of type 'char *' discards qualifiers
  if (!m) nrerror("allocation failure in convert_matrix()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:276:19: warning: passing 'const char [35]' to parameter of type 'char *' discards qualifiers
  if (!t) nrerror("allocation failure 1 in f3tensor()");
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:283:24: warning: passing 'const char [35]' to parameter of type 'char *' discards qualifiers
  if (!t[nrl]) nrerror("allocation failure 2 in f3tensor()");
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
./nrutil.h:290:29: warning: passing 'const char [35]' to parameter of type 'char *' discards qualifiers
  if (!t[nrl][ncl]) nrerror("allocation failure 3 in f3tensor()");
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
In file included from svd.c:3:
./svd.h:142:27: warning: passing 'const char [39]' to parameter of type 'char *' discards qualifiers
                        if (its == 30) nrerror("no convergence in 30 svdcmp iterations");
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nrutil.h:91:19: note: passing argument to parameter 'error_text' here
void nrerror(char error_text[])
                  ^
svd.c:24:3: error: non-void function 'decompose' should return a value [-Wreturn-type]
                return;
                ^
17 warnings and 1 error generated.
make: *_\* [svd.o] Error 1

Gem files will remain installed in /Users/ryan/.rvm/gems/ruby-1.9.3-p125@4seg/gems/ruby-svd-0.5.1 for inspection.
Results logged to /Users/ryan/.rvm/gems/ruby-1.9.3-p125@4seg/gems/ruby-svd-0.5.1/ext/gem_make.out
