### PR TITLE
Improve error handling

### DIFF
--- a/ext/nrutil.h
+++ b/ext/nrutil.h
@@ -88,6 +88,7 @@ float *vector();
 /* function definition */
 
 
+#if 0
 void nrerror(char error_text[])
      /* Numerical Recipes standard error handler */
 {
@@ -96,6 +97,7 @@ void nrerror(char error_text[])
   fprintf(stderr, "...now exiting to system...\n");
   exit(1);
 }
+#endif
 
 float *vector(long nl, long nh)
      /* allocate a float vector with subscript range v[nl..nr] */

--- a/ext/svd.c
+++ b/ext/svd.c
@@ -21,6 +21,8 @@ VALUE decompose(VALUE module, VALUE matrix_ruby, VALUE m_ruby, VALUE n_ruby) {
 	/* precondition */
 	if((m*n) != RARRAY_LEN(matrix_ruby)) {
 		rb_raise(rb_eRangeError, "Size of the array is not equal to m * n");
+	}else if(m<n){
+	  rb_raise(rb_eRangeError, "m(%d) must be greater than or equal to n(%d)", m, n);
 	}
 	
 	/* convert to u matrix */

--- a/ext/svd.c
+++ b/ext/svd.c
@@ -21,7 +21,6 @@ VALUE decompose(VALUE module, VALUE matrix_ruby, VALUE m_ruby, VALUE n_ruby) {
 	/* precondition */
 	if((m*n) != RARRAY_LEN(matrix_ruby)) {
 		rb_raise(rb_eRangeError, "Size of the array is not equal to m * n");
-		return;
 	}
 	
 	/* convert to u matrix */
@@ -64,3 +63,9 @@ void Init_svd()
 	VALUE module = rb_define_module("SVD");
 	rb_define_module_function(module, "decompose", decompose, 3);
 }		
+
+void nrerror(char error_text[])
+     /* Numerical Recipes standard error handler */
+{
+  rb_raise(rb_eRuntimeError, "Numerical Recipes run-time error...\n%s\n", error_text);
+}


### PR DESCRIPTION
Replace exit() with rb_raise() in nerror(), and add rb_raise() when row_size is smaller than column_size.
